### PR TITLE
roboMakerSettings.json - Security Groups - do not merge

### DIFF
--- a/roboMakerSettings.json
+++ b/roboMakerSettings.json
@@ -118,7 +118,7 @@
               "subnet-93e4dccf"
             ],
             "securityGroups": [
-              "sg-030d59568d7d76eab"
+              "sg-030d59568d7d76eab" #  # my security group is sg-0cd53aa93965f9044 // https://www.youtube.com/watch?v=fK6Qsc01YHA @ 19:32
             ],
             "assignPublicIp": true
           },


### PR DESCRIPTION
This is just to show what my security group is, a good idea is also to check out this thread: https://awsjplosrdrl.slack.com/archives/CS800JX25/p1579515040000500

Do not merge - comments only work in some .json libraries - // - and I've used python styling comments just to make it easier to see

Comment here what your security groups are and also what I can do to change these since they're probably different to yours. I'm on the North Virginia AWS set-up